### PR TITLE
adding a square video constraint

### DIFF
--- a/imageclassifier/imageclassifier-on-webcam/sketch.js
+++ b/imageclassifier/imageclassifier-on-webcam/sketch.js
@@ -49,8 +49,17 @@ async function setup() {
 }
 
 function setupVideo() {
+  // has to be a square video and image feed
+  let constraints = {
+    video: {
+      width: size,
+      height: size,
+      aspectRatio: 1
+    } 
+  };
+
   // Get videos from webcam
-  video = createCapture(VIDEO);
+  video = createCapture(VIDEO, constraints);
 
   // Hide the video
   video.hide()


### PR DESCRIPTION
I found out processing does in fact let you add constraints to the video element :) The documentation is [here](https://github.com/processing/p5.js/blob/f55c878f143febdefb7bf8f31fac9df5e15b822a/lib/addons/p5.dom.js#L1327). 

I'm passing square constraints to the video feed because the model requires it. 